### PR TITLE
Pin `scgpt` version

### DIFF
--- a/README.md
+++ b/README.md
@@ -70,7 +70,7 @@ conda create -y --name scgenept python=3.10 # or python3.10 -m venv scgenept
 source activate scgenept
 pip install -r requirements.txt
 pip install flash-attn --no-build-isolation
-pip install scgpt "flash-attn<1.0.5"
+pip install scgpt==0.2.1 "flash-attn<1.0.5"
 ```
 
 **Step 4: Training Data** <br>
@@ -113,7 +113,7 @@ For inference, we recommend not using flash attention:
 python3.10 -m venv scgenept
 source scgenept/bin/activate
 pip install -r requirements.txt
-pip install scgpt 
+pip install scgpt==0.2.1 
 ```
 
 Same tutorial can be found as a Google Collab notebook [here]()

--- a/tutorials/scgenept_tutorial.ipynb
+++ b/tutorials/scgenept_tutorial.ipynb
@@ -73,7 +73,7 @@
     "source activate scgenept\n",
     "pip install -r requirements.txt\n",
     "pip install flash-attn --no-build-isolation\n",
-    "pip install scgpt \"flash-attn<1.0.5\"\n",
+    "pip install scgpt==0.2.1 \"flash-attn<1.0.5\"\n",
     "```\n",
     "\n",
     "2. Once you have a venv created, activate it and allow the jupyter notebook to use it as a kernel by running the following command from the terminal. If jupyter is not installed, it should be:\n",


### PR DESCRIPTION
Using current version of `scgpt` breaks the tutorial because of conflicting dependencies.

Quick fix is to pin version of `scgpt` used.